### PR TITLE
Add legal docs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -36,7 +36,16 @@ export default defineConfig({
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Whitepaper', link: '/learn/whitepaper' }
+      { text: 'Whitepaper', link: '/learn/whitepaper' },
+      {
+        text: 'Codex',
+        items: [
+          { text: 'About', link: '/codex/about' },
+          { text: 'Security', link: '/codex/security' },
+          { text: 'Privacy Policy', link: '/codex/privacy-policy' },
+          { text: 'Terms of Use', link: '/codex/terms-of-use' }
+        ]
+      }
     ],
 
     search: {
@@ -86,6 +95,16 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'API', link: '/developers/api' }
+        ]
+      },
+      {
+        text: 'Codex',
+        collapsed: false,
+        items: [
+          { text: 'About', link: '/codex/about' },
+          { text: 'Security', link: '/codex/security' },
+          { text: 'Privacy Policy', link: '/codex/privacy-policy' },
+          { text: 'Terms of Use', link: '/codex/terms-of-use' }
         ]
       }
     ],

--- a/codex/about.md
+++ b/codex/about.md
@@ -1,0 +1,3 @@
+# About Codex
+
+ Work in progress :construction:

--- a/codex/privacy-policy.md
+++ b/codex/privacy-policy.md
@@ -1,0 +1,69 @@
+# Privacy Policy
+
+Last updated: 9 February 2024
+
+This Privacy Policy is intended to inform users of our approach to privacy in respect of this website (**"Website"**). In this regard, if you are visiting our Website, this Privacy Policy applies to you.
+
+### 1) Who we are
+
+For the purposes of this Privacy Policy and the collection and processing of personal data as a controller, the relevant entity is the Logos Collective Association, which has its registered office in Zug and its legal domicile address at
+
+```
+Logos Collective Association
+c/o PST Consulting GmbH
+Baarerstrasse 10
+6300 Zug
+Switzerland
+```
+
+Whenever we refer to “Logos”, “we” or other similar references, we are referring to the Logos Collective Association.
+
+### 2) We limit the collection and processing of personal data from your use of the Website
+
+We aim to limit the collection and collection and processing of personal data from users of the Website. We only collect and process certain personal data for specific purposes and where we have the legal basis to do so under applicable privacy legislation. We will not collect or process any personal data that we don’t need and where we do store any personal data, we will only store it for the least amount of time needed for the indicated purpose.
+
+In this regard, we collect and process the following personal data from your use of the Website:
+
+* **IP address**: As part of such use of the Website, we briefly process your IP address but we have no way of identifying you. We however have a legitimate interest in processing such IP addresses to ensure the technical functionality and enhance the security measures of the Website. This IP address is not stored by us over time.
+
+### 3) Third party processing of personal data
+
+In addition to our limited and collection of personal data, third parties may collect or process personal data as a result of the Website making use of certain features or to provide certain content. To the extent you interact with such third party content or features, their respective privacy policies will apply.
+
+### 4) Security measures we take in respect of the Website
+
+As a general approach, we take data security seriously and we have implemented a variety of security measures on the Website to maintain the safety of your personal data when you submit such information to us.
+
+### 5) Exporting data outside the European Union and Switzerland
+
+We are obliged to protect the privacy of personal data that you may have submitted in the unlikely event that we export your personal data to places outside the European Union or Switzerland. This means that personal data will only be processed in countries or by parties that provide an adequate level of protection as deemed by Switzerland or the European Commission. Otherwise, we will use other forms of protections, such as specific forms of contractual clauses to ensure such personal data is provided the same protection as required in Switzerland or Europe. In any event, the transmission of personal data outside the European Union and Switzerland will always occur in conformity with applicable privacy legislation. 
+
+### 6) Your choices and rights
+
+As explained in this Privacy Policy, we limit our collection and processing of your personal data wherever possible. Nonetheless, you still have certain choices and rights in respect of the personal data which we do collect and process. As laid out in relevant privacy legislation, you have the right to:
+
+* Ask us to correct or update your personal data (where reasonably possible);
+
+* Ask us to remove your personal data from our systems;
+
+* Ask us for a copy of your personal data, which may also be transferred to another data controller at your request;
+
+* Withdraw your consent to process your personal data (only if consent was asked for a processing activity), which only affects processing activities that are based on your consent and doesn’t affect the validity of such processing activities before you have withdrawn your consent;
+
+* Object to the processing of your personal data; and
+
+* File a complaint with the Federal Data Protection and Information Commissioner (FDPIC), if you believe that your personal data has been processed unlawfully.
+
+### 7) Third party links
+
+On this Website, you may come across links to third party websites. These third party sites have separate and independent privacy policies. We therefore have no responsibility or liability for the content and activities of these third party websites.
+
+### 8) This Privacy Policy might change
+
+We may modify or replace any part of this Privacy Policy at any time and without notice. Please check the Website periodically for any changes. The new Privacy Policy will be effective immediately upon its posting on our Website.
+
+### 9) Contact information
+
+To the extent that you have any questions about the Privacy Policy, please contact us at <a href="mailto:legal@free.technology">legal@free.technology</a>.
+
+This document is licensed under CC-BY-SA.

--- a/codex/security.md
+++ b/codex/security.md
@@ -1,0 +1,7 @@
+# Security
+
+We take security seriously at Codex and across the <a href="https://free.technology/" target="_blank">Institute of Free Technology</a> and its affiliates.
+
+Please report any security incidents via <a href="mailto:security@free.technology">security@free.technology</a>.
+
+Please report any discovered vulnerabilities in our bounty programme at <a href="https://hackenproof.com/ift" target="_blank">HackenProof</a> to help ensure our protocols and software remain secure.

--- a/codex/terms-of-use.md
+++ b/codex/terms-of-use.md
@@ -1,0 +1,93 @@
+# Terms of Use
+
+Last updated: 14 February 2024
+
+These website terms of use ("**Website Terms of Use**") are entered into by you and us, and they govern your access and use of this Website, including any content and functionality contained in the Website.
+
+It is your responsibility to read the Website Terms of Use carefully before your use of the Website and your use of the Website means you have agreed to be bound and comply with these Website Terms of Use.
+
+If you do not agree with these Website Terms of Use, you must not access or use the Website.
+
+### 1) Who we are
+
+For the purposes of these Website Terms of Use, the relevant entity is the Logos Collective Association, which has its registered office in Zug and its legal domicile address at:
+
+```
+Logos Collective Association
+c/o PST Consulting GmbH
+Baarerstrasse 10
+6300 Zug
+Switzerland
+```
+
+Whenever we refer to "Logos", "we", "us" or any other similar references, we are referring to the Logos Collective Association.
+
+### 2) Disclaimers
+
+The Website is provided by us on an ‘as is’ basis and you use the Website at your own sole discretion and risk.
+
+We disclaim all warranties of any kind, express or implied, including without limitation the warranties of merchantability, fitness for a particular purpose, and non-infringement of intellectual property or other violation of rights. We do not warrant or make any representations concerning the completeness, accuracy, legality, utility, reliability, suitability or availability of the use of the Website, the content on this Website or otherwise relating to the Website, such content or on any sites linked to this site.These disclaimers will apply to the maximum extent permitted by applicable law.
+
+We make no claims that the Website or any of its content is accessible, legally compliant or appropriate in your jurisdiction. Your access or use of the Website is at your own sole discretion and you are solely responsible for complying with any applicable local laws.
+
+The content herein or as accessible through this website is intended to be made available for informational purposes only and should not be considered as creating any expectations or forming the basis of any contract, commitment or binding obligation with us. No information herein shall be considered to contain or be relied upon as a promise, representation, warranty or guarantee, whether express or implied and whether as to the past, present or the future in relation to the projects and matters described herein.
+
+The information contained herein does not constitute financial, legal, tax, or other advice and should not be treated as such.
+
+Nothing in this Website should be construed by you as an offer to buy or sell, or soliciting any offer to buy or sell any tokens or any security.
+
+### 3) Forward looking statements
+
+The Website may also contain forward-looking statements that are based on current expectations, estimates, forecasts, assumptions and projections about the technology, industry and markets in general.
+
+The forward looking statements, which may include statements about the roadmap, project descriptions, technical details, functionalities, features, the development and use of tokens by projects, and any other statements related to such matters or as accessible through this website are subject to a high degree of risk and uncertainty. The forward looking statements are subject to change based on, among other things, market conditions, technical developments, and regulatory environment. The actual development and results, including the order and the timeline, might vary from what’s presented. The information contained herein is a summary and does not purport to be accurate, reliable or complete and we bear no responsibility for the accuracy, reliability or completeness of information contained herein. Because of the high degree of risk and uncertainty described above, you should not place undue reliance on any matters described in this website or as accessible through this website.
+
+While we aim to update our website regularly, all information, including the timeline and the specifics of each stage, is subject to change and may be amended or supplemented at any time, without notice and at our sole discretion.
+
+### 4) Intellectual property rights
+
+The Website and its contents are made available under Creative Commons Attribution 4.0 International license (CC-BY 4.0). In essence this licence allows users to copy, modify and distribute the content in any format for any purpose, including commercial use, subject to certain requirements such as attributing us. For the full terms of this licence, please refer to the following website: https://creativecommons.org/licenses/by/4.0/.
+
+### 5) Third party website links
+
+To the extent the Website provides any links to a third party website, then their terms and conditions, including privacy policies, govern your use of those third party websites. By linking such third party websites, Status does not represent or imply that it endorses or supports such third party websites or content therein, or that it believes such third party websites and content therein to be accurate, useful or non-harmful. We have no control over such third party websites and will not be liable for your use of or activities on any third party websites accessed through the Website. If you access such third party websites through the Website, it is at your own risk and you are solely responsible for your activities on such third party websites.
+
+### 6) Limitation of liability
+
+We will not be held liable to you under any contract, negligence, strict liability, or other legal or equitable theory for any lost profits, cost of procurement for substitute services, or any special, incidental, or consequential damages related to, arising from, or in any way connected with these Website Terms of Use, the Website, the content on the Website, or your use of the Website, even if we have been advised of the possibility of such damages. In any event, our aggregate liability for such claims is limited to EUR 100 (one hundred Euros). This limitation of liability will apply to the maximum extent permitted by applicable law.
+
+### 7) Indemnity
+
+You shall indemnify us and hold us harmless from and against any and all claims, damages and expenses, including attorneys’ fees, arising from or related to your use of the Website, the content on the Website, including without limitation your violation of these Website Terms of Use.
+
+### 8) Modifications
+
+We may modify or replace any part of this Website Terms of Use at any time and without notice. You are responsible for checking the Website periodically for any changes. The new Website Terms of Use will be effective immediately upon its posting on the Website.
+
+### 9) Governing law
+
+Swiss law governs these Website Terms of Use and any disputes between you and us, whether in court or arbitration, without regard to conflict of laws provisions.
+
+### 10) Disputes
+
+In these terms, “dispute” has the broadest meaning enforceable by law and includes any claim you make against or controversy you may have in relation to these Website Terms of Use, the Website, the content on the Website, or your use of the Website.
+
+We prefer arbitration over litigation as we believe it meets our principle of resolving disputes in the most effective and cost effective manner. You are bound by the following arbitration clause, which waives your right to litigation and to be heard by a judge. Please note that court review of an arbitration award is limited. You also waive all your rights to a jury trial (if any) in any and all jurisdictions.
+
+If a (potential) dispute arises, you must first use your reasonable efforts to resolve it amicably with us. If these efforts do not result in a resolution of such dispute, you shall then send us a written notice of dispute setting out (i) the nature of the dispute, and the claim you are making; and (ii) the remedy you are seeking.
+
+If we and you are unable to further resolve this dispute within sixty (60) calendar days of us receiving this notice of dispute, then any such dispute will be referred to and finally resolved by you and us through an arbitration administered by the Swiss Chambers’ Arbitration Institution in accordance with the Swiss Rules of International Arbitration for the time being in force, which rules are deemed to be incorporated herein by reference. The arbitral decision may be enforced in any court. The arbitration will be held in Zug, Switzerland, and may be conducted via video conference virtual/online methods if possible. The tribunal will consist of one arbitrator, and all proceedings as well as communications between the parties will be kept confidential. The language of the arbitration will be in English. Payment of all relevant fees in respect of the arbitration, including filing, administration and arbitrator fees will be in accordance with the Swiss Rules of International Arbitration.
+
+Regardless of any applicable statute of limitations, you must bring any claims within one year after the claim arose or the time when you should have reasonably known about the claim. You also waive the right to participate in a class action lawsuit or a classwide arbitration against us.
+
+### 11) About these Website Terms of Use
+
+These Website Terms of Use cover the entire agreement between you and us regarding the Website and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Website.
+
+The captions and headings identifying sections and subsections of these Website Terms of Use are for reference only and do not define, modify, expand, limit, or affect the interpretation of any provisions of these Website Terms of Use.
+
+If any part of these Website Terms of Use is held invalid or unenforceable, that part will be severable from these Website Terms of Use, and the remaining portions will remain in full force and effect. If we fail to enforce any of these Website Terms of Use, that does not mean that we have waived our right to enforce them.
+
+If you have any specific questions about these Website Terms of Use, please contact us at <a href="mailto:legal@free.technology">llegal@free.technology</a>.
+
+This document is licensed under CC-BY-SA.


### PR DESCRIPTION
As we discussed with @jessiebroke, basic legal docs should be added to the documentation site.

It is almost full copy/paste from the previous ones - [`docs.codex.storage/develop/docs`](https://github.com/codex-storage/docs.codex.storage/tree/develop/docs) and `security.md` was copied as well.