### PR TITLE
Quick-start guide

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -79,9 +79,7 @@ export default defineConfig({
           { text: 'Architecture', link: '/learn/architecture' },
           { text: 'Marketplace', link: '/learn/marketplace' },
           { text: 'Whitepaper', link: '/learn/whitepaper' },
-          { text: 'Build Codex', link: '/learn/build' },
-          { text: 'Run Codex', link: '/learn/run' },
-          { text: 'Deploy Codex', link: '/learn/deploy' }
+          { text: 'Build Codex', link: '/learn/build' }
         ]
       },
       {

--- a/developers/api.md
+++ b/developers/api.md
@@ -1,5 +1,4 @@
 # Codex API
 
- Work in progress :construction:
-
- Please read [api.codex.storage](https://api.codex.storage/) for now.
+ See [api.codex.storage](https://api.codex.storage/)
+ See [open-api](https://github.com/codex-storage/nim-codex/blob/master/openapi.yaml)

--- a/learn/build.md
+++ b/learn/build.md
@@ -148,7 +148,7 @@ The default `make` target creates the `build/codex` executable.
 
 ## Example usage
 
-See the instructions in the [Run Codex](/learn/run).
+See the instructions in the [Quick Start](/learn/quick-start).
 
 ## Tests
 

--- a/learn/deploy.md
+++ b/learn/deploy.md
@@ -1,3 +1,0 @@
-# Deploy Codex
-
- Work in progress :construction:

--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -1,6 +1,6 @@
 # Quick start
 
- To start using Codex we would need to perform the following steps:
+ To join the Codex testnet we would need to perform the following steps:
  - [Review the disclaimer](/codex/disclaimer)
  - [Get Codex binary](#get-codex-binary)
  - [Run Codex](#run-codex)
@@ -75,69 +75,16 @@
 
 ### Run Codex
 
- Currently, we can run Codex in two modes:
- - **Client node** - you can upload/download files and purchase storage
- - **Storage node** - you can sell your local storage
+ To run your Codex node and join the testnet, follow the steps in the [codex-testnet-starter](https://github.com/codex-storage/codex-testnet-starter/blob/master/SETUP_HOME.md).
 
- For quick start we will run a Codex client node as an easy way to get started. If you would like to run a storage node please follow [Run Codex](/learn/run) and [Codex Testnet](/networks/testnet) guides.
-
- 1. Run Codex client node
-    ```shell
-    codex \
-      --data-dir=./data \
-      --api-cors-origin="*" \
-      --nat=`curl -s https://ip.codex.storage` \
-      --disc-port=8090 \
-      --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
-      --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P
-    ```
-    ::: tip
-    In the example above we use [Codex Testnet](/networks/testnet#bootstrap-nodes) bootstrap nodes and thus we join Testnet. If you would like to join a different network, please use [appropriate value](/networks/networks).
-    :::
-
- 2. Configure port-forwarding for the TCP/UDP ports on your Internet router
-    | Protocol | Service   | Port   |
-    | -------- | --------- | ------ |
-    | UDP      | Discovery | `8090` |
-    | TCP      | Transport | `8070` |
+ If you want to run Codex locally without joining the testnet, consider trying the [two-client-test](https://github.com/codex-storage/nim-codex/blob/master/docs/TwoClientTest.md) or the [marketplace-test](https://github.com/codex-storage/nim-codex/blob/master/docs/Marketplace.md).
 
 ### Interact with Codex
 
- After we performed the steps above, we have a Codex client node up and running and can interact with it using [Codex API](/developers/api).
+ When your Codex node is up and running you can interact with it using [Codex API](/developers/api).
 
- We can perform basic tasks:
+ For a walk-through of the API, consider following the [using-codex](https://github.com/codex-storage/codex-testnet-starter/blob/master/USINGCODEX.md) guide.
 
- **Check node information**
- ```shell
- curl http://localhost:8080/api/codex/v1/debug/info \
-  --write-out '\n'
- ```
+### Stay in touch
 
- **Upload file**
- ::: warning
- Once you upload a file to Codex, other nodes in the network can download it.
- :::
- ```shell
- curl --request POST \
-  http://localhost:8080/api/codex/v1/data \
-  --header 'Content-Type: application/octet-stream' \
-  --write-out '\n' \
-  -T <FILE>
- ```
- You will get CID when upload will be finished.
-
- **Download file**
- ```shell
- CID="..." # paste your CID from the previous step here between the quotes.
- ```
- ```shell
- curl http://localhost:8080/api/codex/v1/data/${CID}/network -o ${CID}
- ```
-
-### Next steps
-
- Now we have a Codex node up and running and know how to interact with it.
-
- For more advanced use cases, please check the following guides:
- - [Run Codex](/learn/run)
- - [Codex Testnet](/networks/testnet)
+ Want to stay up-date, or looking for further assistence? Try our [discord-server](https://discord.gg/codex-storage).

--- a/learn/run.md
+++ b/learn/run.md
@@ -1,7 +1,0 @@
-# Run Codex
-
- Work in progress :construction:
-
- Please read
- - [Codex Two-Client Test](https://github.com/codex-storage/nim-codex/blob/master/docs/TwoClientTest.md)
- - [Running a Local Codex Network with Marketplace Support](https://github.com/codex-storage/nim-codex/blob/master/docs/Marketplace.md)


### PR DESCRIPTION
It now directs to the codex-testnet-starter as per instructions from Jessie.
Starter guides both setup and usage have been updated.
Checked and working for: 
 - Win + client (not storage provider)
 - Docker + client (not storage provider)
