### PR TITLE
Set custom link to the nav

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -68,6 +68,8 @@ export default defineConfig({
 
     siteTitle: 'Codex • Docs',
 
+   logoLink: '/learn/what-is-codex',
+
     sidebar: [
       {
         text: 'Introduction',


### PR DESCRIPTION
During the meeting we discussed an option to set a link to the nav element

Preview - https://feat-set-custom-link-to-nav.codex-docs-8lf.pages.dev

<img width="746" alt="Screenshot 2024-09-26 at 15 18 31" src="https://github.com/user-attachments/assets/17a663dd-6b29-4d67-b57d-84b49993fb51">
