### PR TITLE
Split guide for Linux/macOS and Windows

### DIFF
--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -10,9 +10,13 @@
 
  For quick start we will use precompiled binaries from [GitHub release page](https://github.com/codex-storage/nim-codex/releases). If you prefer to compile from the sources, please check [Build Codex](/learn/build).
 
- 1. Download binary and checksum for your platform/architecture
+ Please follow the steps for your OS from the list:
+ - [Linux/macOS](#linux-macos)
+ - [Windows](#windows)
 
-    **Linux/macOS**
+#### Linux/macOS
+
+ 1. Download binary and checksum for your platform/architecture
     ```shell
     version=v0.1.4
     platform=$(echo `uname -s` | awk '{print tolower($0)}')
@@ -23,22 +27,6 @@
 
     # Checksum
     curl -LO https://github.com/codex-storage/nim-codex/releases/download/${version}/codex-${version}-${platform}-${architecture}.tar.gz.sha256
-    ```
-
-    **Windows**
-    ::: warning
-    For Windows, only amd64 architecture is supported now.
-    :::
-    ```batch
-    set version=v0.1.4
-    set platform=windows
-    if %PROCESSOR_ARCHITECTURE%==AMD64 (set architecture=amd64) else (set architecture=arm64)
-
-    :: Binary
-    curl -LO https://github.com/codex-storage/nim-codex/releases/download/%version%/codex-%version%-%platform%-%architecture%-libs.zip
-
-    :: Checksum
-    curl -LO https://github.com/codex-storage/nim-codex/releases/download/%version%/codex-%version%-%platform%-%architecture%-libs.zip.sha256
     ```
 
  2. Verify checksum
@@ -53,46 +41,19 @@
     shasum -a 256 -c codex-${version}-${platform}-${architecture}.tar.gz.sha256
     ```
 
-    **Windows**
-    ```batch
-    for /f "delims=" %a in ('certUtil -hashfile codex-%version%-%platform%-%architecture%-libs.zip SHA256 ^| findstr -vrc:"[^0123-9aAb-Cd-EfF ]"') do @set ACTUAL_HASH=%a
-    for /f "tokens=1" %a in (codex-%version%-%platform%-%architecture%-libs.zip.sha256) do set EXPECTED_HASH=%a
-    if %ACTUAL_HASH% == %EXPECTED_HASH% (echo. && echo codex-%version%-%platform%-%architecture%-libs.zip: OK) else (echo. && echo codex-%version%-%platform%-%architecture%-libs.zip: FAILED)
-    ```
-
     Make sure you get `OK` in the result
     ```
     codex-v0.1.4-linux-amd64.tar.gz: OK
     ```
 
  3. Extract binary
-
-    **Linux/macOS**
     ```shell
     tar -zxvf codex-${version}-${platform}-${architecture}.tar.gz
     ```
 
  4. Copy binary to the appropriate folder
-
-    **Linux/macOS**
     ```shell
     sudo install codex-${version}-${platform}-${architecture} /usr/local/bin/codex
-    ```
-
-    **Windows**
-    ```batch
-    :: Extract binary and libraries to the appropriate folder
-    if not exist %LOCALAPPDATA%\Codex mkdir %LOCALAPPDATA%\Codex
-    tar -xvf codex-%version%-%platform%-%architecture%-libs.zip -C %LOCALAPPDATA%\Codex
-
-    :: Rename binary
-    move /Y %LOCALAPPDATA%\Codex\codex-%version%-%platform%-%architecture%.exe %LOCALAPPDATA%\Codex\codex.exe
-
-    :: Add folder to the path permanently
-    setx PATH %PATH%%LOCALAPPDATA%\Codex;
-
-    :: Add folder to the path for the current session
-    PATH %PATH%%LOCALAPPDATA%\Codex;
     ```
 
  5. Install dependencies
@@ -112,8 +73,6 @@
     ```
 
  7. Cleanup
-
-    **Linux/macOS**
     ```shell
     rm -f \
       codex-${version}-${platform}-${architecture} \
@@ -121,7 +80,68 @@
       codex-${version}-${platform}-${architecture}.tar.gz.sha256
     ```
 
-    **Windows**
+#### Windows
+
+ 1. Download binary and checksum for your platform/architecture
+    ::: warning
+    For Windows, only amd64 architecture is supported now.
+    :::
+    ```batch
+    set version=v0.1.4
+    set platform=windows
+    if %PROCESSOR_ARCHITECTURE%==AMD64 (set architecture=amd64) else (set architecture=arm64)
+
+    :: Binary
+    curl -LO https://github.com/codex-storage/nim-codex/releases/download/%version%/codex-%version%-%platform%-%architecture%-libs.zip
+
+    :: Checksum
+    curl -LO https://github.com/codex-storage/nim-codex/releases/download/%version%/codex-%version%-%platform%-%architecture%-libs.zip.sha256
+    ```
+
+ 2. Verify checksum
+    ```batch
+    for /f "delims=" %a in ('certUtil -hashfile codex-%version%-%platform%-%architecture%-libs.zip SHA256 ^| findstr -vrc:"[^0123-9aAb-Cd-EfF ]"') do @set ACTUAL_HASH=%a
+    for /f "tokens=1" %a in (codex-%version%-%platform%-%architecture%-libs.zip.sha256) do set EXPECTED_HASH=%a
+    if %ACTUAL_HASH% == %EXPECTED_HASH% (echo. && echo codex-%version%-%platform%-%architecture%-libs.zip: OK) else (echo. && echo codex-%version%-%platform%-%architecture%-libs.zip: FAILED)
+    ```
+
+    Make sure you get `OK` in the result
+    ```
+    codex-v0.1.4-windows-amd64-libs.zip: OK
+    ```
+
+ 3. Extract binary and libraries
+    ```batch
+    if not exist %LOCALAPPDATA%\Codex mkdir %LOCALAPPDATA%\Codex
+    tar -xvf codex-%version%-%platform%-%architecture%-libs.zip -C %LOCALAPPDATA%\Codex
+
+ 4. Rename binary and update user `path` variable
+    ```batch
+    :: Rename binary
+    move /Y %LOCALAPPDATA%\Codex\codex-%version%-%platform%-%architecture%.exe %LOCALAPPDATA%\Codex\codex.exe
+
+    :: Add folder to the path permanently
+    setx PATH %PATH%%LOCALAPPDATA%\Codex;
+
+    :: Add folder to the path for the current session
+    PATH %PATH%%LOCALAPPDATA%\Codex;
+    ```
+
+ 4. Check the result
+    ```shell
+    codex --version
+    ```
+    ```shell
+    Codex version:  v0.1.4
+    Codex revision: 484124d
+    Nim Compiler Version 1.6.14 [Windows: amd64]
+    Compiled at 2024-06-27
+    Copyright (c) 2006-2023 by Andreas Rumpf
+    git hash: 38640664088251bbc88917b4bacfd86ec53014b8
+    active boot switches: -d:release
+    ```
+
+ 5. Cleanup
     ```batch
     del codex-%version%-%platform%-%architecture%-libs.zip ^
       codex-%version%-%platform%-%architecture%-libs.zip.sha256
@@ -141,4 +161,4 @@
 
 ### Stay in touch
 
- Want to stay up-date, or looking for further assistence? Try our [discord-server](https://discord.gg/codex-storage).
+ Want to stay up-date, or looking for further assistance? Try our [discord-server](https://discord.gg/codex-storage).


### PR DESCRIPTION
It was decided to make a split of the existing guide into a separate chapters for Linux/macOS and Windows.

In that way we can follow it much easier.