### PR TITLE
Small fixes

### DIFF
--- a/developers/api.md
+++ b/developers/api.md
@@ -1,4 +1,5 @@
 # Codex API
 
- See [api.codex.storage](https://api.codex.storage/)
- See [open-api](https://github.com/codex-storage/nim-codex/blob/master/openapi.yaml)
+ Codex uses REST API to interact with the node and we can use HTTP client for interaction and configuration.
+
+ API specification can be found on the [api.codex.storage](https://api.codex.storage) and it is generated based on [openapi.yaml](https://github.com/codex-storage/nim-codex/blob/master/openapi.yaml).

--- a/learn/run.md
+++ b/learn/run.md
@@ -360,7 +360,7 @@ To download circuit files and make them available to Codex app, we have a stand-
      --eth-private-key=eth.key \
      --marketplace-address=0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6 \
      prover \
-     --circuit-dir
+     --circuit-dir=datadir/circuits
    ```
 
 > [!NOTE]
@@ -547,9 +547,7 @@ For Docker Compose, it is more suitable to use [environment variables](#environm
           - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage
           - CODEX_ETH_PRIVATE_KEY=/opt/eth.key
           - CODEX_MARKETPLACE_ADDRESS=0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6
-          - CODEX_CIRCOM_R1CS=/datadir/circuits/proof_main.r1cs
-          - CODEX_CIRCOM_WASM=/datadir/circuits/proof_main.wasm
-          - CODEX_CIRCOM_ZKEY=/datadir/circuits/proof_main.zkey
+          - CODEX_CIRCUIT_DIR=/datadir/circuits
         ports:
           - 8080:8080/tcp # API
           - 8090:8090/udp # Discovery

--- a/learn/using.md
+++ b/learn/using.md
@@ -1,7 +1,8 @@
 # Using Codex
-Codex's web-API is documented: [Here](https://github.com/codex-storage/nim-codex/blob/master/openapi.yaml)
 
 This document will show you several useful API calls.
+
+For more information about Codex API is documented: [Here](https://github.com/codex-storage/nim-codex/blob/master/openapi.yaml)
 
 ## Overview
 1. [Debug](#debug)
@@ -12,34 +13,32 @@ This document will show you several useful API calls.
 6. [Purchase storage](#purchase-storage)
 7. [View purchase status](#view-purchase-status)
 
-
 ## Debug
 An easy way to check that your node is up and running is:
 
 ```shell
 curl http://localhost:8080/api/codex/v1/debug/info \
-  --write-out '\n'
+  -w '\n'
 ```
 
 This will return a JSON structure with plenty of information about your local node. It contains peer information that may be useful when troubleshooting connection issues.
-
 
 ## Upload a file
 > [!Warning]
 > Once you upload a file to Codex, other nodes in the network can download it. Please do not upload anything you don't want others to access, or, properly encrypt your data *first*.
 
 ```shell
-curl --request POST \
+curl -X POST \
   http://localhost:8080/api/codex/v1/data \
-  --header 'Content-Type: application/json' \
-  --write-out '\n' \
+  -H 'Content-Type: application/octet-stream' \
+  -w '\n' \
   -T <FILE>
 ```
 
 On successful upload, you'll receive a CID. This can be used to download the file from any node in the network.
 
 > [!TIP]
-> Are you on the [Codex Discord server](https://discord.gg/codex-storage)? Post your CID in the [#testnet](https://discord.com/channels/895609329053474826/1278383098102284369) channel, see if others are able to download it. Codex does not (yet?) provide file metadata, so if you want others to be able to open your file, tell them which extension to give it.
+> Are you on the [Codex Discord server](https://discord.gg/codex-storage)? Post your CID in the [# :wireless: | share-cids](https://discord.com/channels/895609329053474826/1278383098102284369) channel, see if others are able to download it. Codex does not (yet?) provide file metadata, so if you want others to be able to open your file, tell them which extension to give it.
 
 ## Download a file
 When you have a CID of data you want to download, you can use the following commands:
@@ -49,17 +48,18 @@ CID="..." # paste your CID from the previous step here between the quotes
 ```
 
 ```shell
-curl -o "${CID}.png" "http://localhost:8080/api/codex/v1/data/${CID}/network"
+curl "http://localhost:8080/api/codex/v1/data/${CID}/network" \
+  -o "${CID}.png"
 ```
 
 Please use the correct extension for the downloaded file, because Codex does not store yet content-type or extension information.
 
 ## Local data
-You can view which datasets are currently being stored by your node.
+You can view which datasets are currently being stored by your node:
 
 ```shell
 curl http://localhost:8080/api/codex/v1/data \
-  --write-out '\n'
+  -w '\n'
 ```
 
 ## Create storage availability
@@ -69,11 +69,11 @@ curl http://localhost:8080/api/codex/v1/data \
 In order to start selling storage space to the network, you must configure your node with the following command. Once configured, the node will monitor on-chain requests-for-storage and will automatically enter into contracts that meet these specifications. In order to enter and maintain storage contracts, your node is required to submit zero-knowledge storage proofs. The calculation of these proofs will increase the CPU and RAM usage of Codex.
 
 ```shell
-curl --request POST \
+curl -X POST \
   http://localhost:8080/api/codex/v1/sales/availability \
-  --header 'Content-Type: application/json' \
-  --write-out '\n' \
-  --data '{
+  -H 'Content-Type: application/json' \
+  -w '\n' \
+  -d '{
     "totalSize": "8000000",
     "duration": "7200",
     "minPrice": "10",
@@ -96,10 +96,10 @@ echo "CID: ${CID}"
 Next you can run:
 
 ```shell
-curl --request POST \
+curl -X POST \
   "http://localhost:8080/api/codex/v1/storage/request/${CID}" \
-  --write-out '\n' \
-  --data '{
+  -w '\n' \
+  -d '{
     "duration": "3600",
     "reward": "1",
     "proofProbability": "5",
@@ -114,7 +114,6 @@ For descriptions of each parameter, please view the [spec](https://api.codex.sto
 
 When successful, this request will return a Purchase-ID.
 
-
 ## View purchase status
 Using a Purchase-ID, you can check the status of your request-for-storage contract:
 
@@ -126,7 +125,7 @@ Then:
 
 ```shell
 curl "http://localhost:8080/api/codex/v1/storage/purchases/${PURCHASE_ID}" \
-  --write-out '\n'
+  -w '\n'
 ```
 
 This will display state and error information for your purchase.


### PR DESCRIPTION
PR adds the following
- Short update on API page
- For Docker run we missed value for `--circuit-dir` option
- Docker compose now use `CODEX_CIRCUIT_DIR` instead of the variable for a every file
- Using Codex switched to use curl short options as we already used them - let's have a unified approach
- Update link to the Discord channel for CID sharing