### PR TITLE
Add a Basic guide for Windows

### DIFF
--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -192,7 +192,7 @@ If you would like to purchase or sell storage, please consider to run [Codex nod
 
 ## Interact with Codex
 
-When your Codex node is up and running you can interact with it using [Codex Marketplace UI](https://marketplace.codex.storage) for files sharing.
+When your Codex node is up and running you can interact with it using [Codex App UI](https://app.codex.storage) for files sharing.
 
 Also, you can interact with Codex using [Codex API](/developers/api) and for a walk-through of the API, consider following the [Using Codex](/learn/using) guide.
 

--- a/learn/run.md
+++ b/learn/run.md
@@ -246,7 +246,7 @@ codex \
 
 After node is up and running and port-forwarding configurations was done, we should be able to [Upload a file](/learn/using#upload-a-file)/[Download a file](/learn/using#download-a-file) in the network using [API](/developers/api).
 
-You also can use [Codex Marketplace UI](https://marketplace.codex.storage) for files upload/download.
+You also can use [Codex App UI](https://app.codex.storage) for files upload/download.
 
 And to be able to purchase a storage, we should run [Codex node with marketplace support](#codex-node-with-marketplace-support).
 
@@ -298,7 +298,7 @@ And to be able to purchase a storage, we should run [Codex node with marketplace
 
 After node is up and running, and your address has founds, you should be able to [Purchase storage](/learn/using#purchase-storage) using [API](/developers/api).
 
-You also can use [Codex Marketplace UI](https://marketplace.codex.storage) for storage purchase.
+You also can use [Codex App UI](https://app.codex.storage) for storage purchase.
 
 #### Codex storage node
 
@@ -369,7 +369,7 @@ To download circuit files and make them available to Codex app, we have a stand-
 
 After node is up and running, and your address has founds, you should be able to [sell the storage](/learn/using#create-storage-availability) using [API](/developers/api).
 
-You also can use [Codex Marketplace UI](https://marketplace.codex.storage) to sell the storage.
+You also can use [Codex App UI](https://app.codex.storage) to sell the storage.
 
 #### Codex bootstrap node
 

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -31,7 +31,11 @@ It is mostly the same as a [Basic guide](#basic-guide), but uses Discord capabil
  - [Git installed](https://git-scm.com/downloads)
  - Configure port forwarding on your Internet router
 
+Steps for [Linux/macOS](#basic-linux-macos) and [Windows](#basic-windows) are slightly different, so please use ones for your OS.
+
 <hr>
+
+### Linux/macOS {#basic-linux-macos}
 
 1. Open console and clone the repository:
    ```shell
@@ -49,38 +53,79 @@ It is mostly the same as a [Basic guide](#basic-guide), but uses Discord capabil
    sudo apt update && sudo apt install libgomp1
    ```
 
-4. Download Codex binaries from GitHub releases
+4. Download Codex binaries from GitHub releases:
    ```shell
    ./download_online.sh
    ```
 
-5. Generate an ethereum keypair
+5. Generate an ethereum keypair:
    ```shell
    ./generate.sh
    ```
    Your private key will be saved to `eth.key` and address to  `eth.address` file.
 
-6. Fill-up your address with tokens
+6. Fill-up your address shown on the screen with the tokens:
    - Use the web faucets to mint some [ETH](https://faucet-eth.testnet.codex.storage) and [TST](https://faucet-tst.testnet.codex.storage) tokens.
    - We can also do this using Discord [# bot](https://discord.com/channels/895609329053474826/1230785221553819669) channel
      - Use `/set ethaddress` command to enter your generated address
      - Use `/mint` command to receive ETH and TST tokens
      - Use `/balance` command to check if you have received test tokens successfully
 
-7. Run Codex node
+7. Run Codex node:
    ```shell
    ./run_client.sh
    ```
 
-8. Configure [port forwarding](https://en.wikipedia.org/wiki/Port_forwarding) on your Internet router
-   | # | Protocol | Port   | Description       |
-   | - | -------- | ------ | ----------------- |
-   | 1 | `UDP`    | `8090` | `Codex Discovery` |
-   | 2 | `TCP`    | `8070` | `Codex Transport` |
+8. Configure [port forwarding](#basic-common) and we are ready go to.
+
+### Windows {#basic-windows}
+
+1. Open command prompt (`cmd`) and clone the repository:
+   ```batch
+   git clone https://github.com/codex-storage/codex-testnet-starter
+   ```
+
+2. Navigate to the scripts folder:
+   ```batch
+   cd codex-testnet-starter\scripts\windows
+   ```
+
+3. Download Codex binaries from GitHub releases:
+   ```batch
+   download-online.bat
+   ```
+
+4. Generate an ethereum keypair:
+   ```batch
+   generate.bat
+   ```
+   Your private key will be saved to `eth.key` and address to  `eth.address` file.
+
+5. Fill-up your address shown on the screen with the tokens:
+   - Use the web faucets to mint some [ETH](https://faucet-eth.testnet.codex.storage) and [TST](https://faucet-tst.testnet.codex.storage) tokens.
+   - We can also do this using Discord [# bot](https://discord.com/channels/895609329053474826/1230785221553819669) channel
+     - Use `/set ethaddress` command to enter your generated address
+     - Use `/mint` command to receive ETH and TST tokens
+     - Use `/balance` command to check if you have received test tokens successfully
+
+6. Run Codex node:
+   ```batch
+   run-client.bat
+   ```
+
+ 7. Configure [port forwarding](#basic-common) and we are ready go to.
+
+### All OS {#basic-common}
+
+Configure [port forwarding](https://en.wikipedia.org/wiki/Port_forwarding) on your Internet router
+| # | Protocol | Port   | Description       |
+| - | -------- | ------ | ----------------- |
+| 1 | `UDP`    | `8090` | `Codex Discovery` |
+| 2 | `TCP`    | `8070` | `Codex Transport` |
 
 After your node is up and running, you can use the [Codex API](/developers/api) to be able to interact with your Codex node, please check our [API walk-through](/learn/using) for more details.
 
-You also can use [Codex Marketplace UI](https://marketplace.codex.storage) to interact with your local Codex node.
+You also can use [Codex App UI](https://app.codex.storage) to interact with your local Codex node.
 
 Need help? Reach out to us in [#:sos:|node-help](https://discord.com/channels/895609329053474826/1286205545837105224) channel or check [troubleshooting guide](#troubleshooting).
 


### PR DESCRIPTION
We just renamed [Codex Marketplace UI](https://marketplace.codex.storage) to the [Codex App UI](https://app.codex.storage) - shorter=nicier.

Also, PR adds a Basic guide to "Join Codex Testnet" for Windows OS.

Before we can merge that PR, it is required to adjust scripts for Windows - [codex-testnet-starter/scripts/windows](https://github.com/codex-storage/codex-testnet-starter/tree/master/scripts/windows).

Branch Preview URL: https://docs-add-basic-guide-for-win.codex-docs-8lf.pages.dev