### PR TITLE
Update Using Codex with steps for Windows

### DIFF
--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -133,7 +133,7 @@ Please follow the steps for your OS from the list:
    ```shell
    Codex version:  v0.1.4
    Codex revision: 484124d
-   Nim Compiler Version 1.6.14 [Windows: amd64]
+   Nim Compiler Version 1.6.21 [Windows: amd64]
    Compiled at 2024-06-27
    Copyright (c) 2006-2023 by Andreas Rumpf
 
@@ -156,12 +156,12 @@ We may [run Codex in different modes](/learn/run#run), and for a quick start we 
    **Linux/macOS**
    ```shell
    codex \
-   --data-dir=datadir \
-   --disc-port=8090 \
-   --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
-   --nat=`curl -s https://ip.codex.storage` \
-   --api-cors-origin="*" \
-   --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P
+     --data-dir=datadir \
+     --disc-port=8090 \
+     --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
+     --nat=`curl -s https://ip.codex.storage` \
+     --api-cors-origin="*" \
+     --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P
    ```
 
    **Windows**
@@ -171,12 +171,12 @@ We may [run Codex in different modes](/learn/run#run), and for a quick start we 
 
    :: Run
    codex ^
-   --data-dir=datadir ^
-   --disc-port=8090 ^
-   --listen-addrs=/ip4/0.0.0.0/tcp/8070 ^
-   --nat=%nat% ^
-   --api-cors-origin="*" ^
-   --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P
+     --data-dir=datadir ^
+     --disc-port=8090 ^
+     --listen-addrs=/ip4/0.0.0.0/tcp/8070 ^
+     --nat=%nat% ^
+     --api-cors-origin="*" ^
+     --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P
    ```
 
    > [!TIP]

--- a/learn/using.md
+++ b/learn/using.md
@@ -1,10 +1,17 @@
+---
+outline: [2, 3]
+---
 # Using Codex
 
-This document will show you several useful API calls.
+We can interact with Codex using [REST API](/developers/api). This document will show you several useful examples.
 
-For more information about Codex API is documented: [Here](https://github.com/codex-storage/nim-codex/blob/master/openapi.yaml)
+Also, we can check [Codex App UI](https://app.codex.storage).
 
-## Overview
+Command line interpreter on [Linux/macOS](#linux-macos) and [Windows](#windows) works slightly different, so please use steps for your OS.
+
+## Linux/macOS
+
+### Overview
 1. [Debug](#debug)
 2. [Upload a file](#upload-a-file)
 3. [Download a file](#download-a-file)
@@ -13,7 +20,7 @@ For more information about Codex API is documented: [Here](https://github.com/co
 6. [Purchase storage](#purchase-storage)
 7. [View purchase status](#view-purchase-status)
 
-## Debug
+### Debug
 An easy way to check that your node is up and running is:
 
 ```shell
@@ -23,7 +30,7 @@ curl http://localhost:8080/api/codex/v1/debug/info \
 
 This will return a JSON structure with plenty of information about your local node. It contains peer information that may be useful when troubleshooting connection issues.
 
-## Upload a file
+### Upload a file
 > [!Warning]
 > Once you upload a file to Codex, other nodes in the network can download it. Please do not upload anything you don't want others to access, or, properly encrypt your data *first*.
 
@@ -40,11 +47,12 @@ On successful upload, you'll receive a CID. This can be used to download the fil
 > [!TIP]
 > Are you on the [Codex Discord server](https://discord.gg/codex-storage)? Post your CID in the [# :wireless: | share-cids](https://discord.com/channels/895609329053474826/1278383098102284369) channel, see if others are able to download it. Codex does not (yet?) provide file metadata, so if you want others to be able to open your file, tell them which extension to give it.
 
-## Download a file
+### Download a file
 When you have a CID of data you want to download, you can use the following commands:
 
 ```shell
-CID="..." # paste your CID from the previous step here between the quotes
+# paste your CID from the previous step here between the quotes
+CID="..."
 ```
 
 ```shell
@@ -54,7 +62,7 @@ curl "http://localhost:8080/api/codex/v1/data/${CID}/network" \
 
 Please use the correct extension for the downloaded file, because Codex does not store yet content-type or extension information.
 
-## Local data
+### Local data
 You can view which datasets are currently being stored by your node:
 
 ```shell
@@ -62,7 +70,7 @@ curl http://localhost:8080/api/codex/v1/data \
   -w '\n'
 ```
 
-## Create storage availability
+### Create storage availability
 > [!WARNING]
 > This step requires that Codex was started with the [`prover`](/learn/run#codex-storage-node) option.
 
@@ -83,13 +91,14 @@ curl -X POST \
 
 For descriptions of each parameter, please view the [spec](https://api.codex.storage/#tag/Marketplace/operation/offerStorage).
 
-## Purchase storage
+### Purchase storage
 To purchase storage space from the network, first you must upload your data. Once you have the CID, use the following to create a request-for-storage.
 
 Set your CID:
 
 ```shell
-CID="..." # paste your CID from the previous step here between the quotes
+# paste your CID from the previous step here between the quotes
+CID="..."
 echo "CID: ${CID}"
 ```
 
@@ -114,10 +123,11 @@ For descriptions of each parameter, please view the [spec](https://api.codex.sto
 
 When successful, this request will return a Purchase-ID.
 
-## View purchase status
+### View purchase status
 Using a Purchase-ID, you can check the status of your request-for-storage contract:
 
 ```shell
+# paste your PURCHASE_ID from the previous step here between the quotes
 PURCHASE_ID="..."
 ```
 
@@ -126,6 +136,128 @@ Then:
 ```shell
 curl "http://localhost:8080/api/codex/v1/storage/purchases/${PURCHASE_ID}" \
   -w '\n'
+```
+
+This will display state and error information for your purchase.
+| State     | Description                                                                                                                                                                                            |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Pending   | Request is waiting for chain confirmation.                                                                                                                                                             |
+| Submitted | Request is on-chain. Hosts may now attempt to download the data.                                                                                                                                       |
+| Started   | Hosts have downloaded the data and provided proof-of-storage.                                                                                                                                          |
+| Failed    | The request was started, but (too many) hosts failed to provide proof-of-storage on time. While the data may still be available in the network, for the purpose of the purchase it is considered lost. |
+| Finished  | The request was started successfully and the duration has elapsed.                                                                                                                                     |
+| Expired   | (Not enough) hosts have submitted proof-of-storage before the request's expiry elapsed.                                                                                                                |
+| Errored   | An unfortunate state of affairs. The 'error' field should tell you more.                                                                                                                               |
+
+## Windows
+
+### Overview {#overview-windows}
+1. [Debug](#debug-windows)
+2. [Upload a file](#upload-a-file-windows)
+3. [Download a file](#download-a-file-windows)
+4. [Local data](#local-data-windows)
+5. [Create storage availability](#create-storage-availability-windows)
+6. [Purchase storage](#purchase-storage-windows)
+7. [View purchase status](#view-purchase-status-windows)
+
+### Debug {#debug-windows}
+An easy way to check that your node is up and running is:
+
+```batch
+curl http://localhost:8080/api/codex/v1/debug/info
+```
+
+This will return a JSON structure with plenty of information about your local node. It contains peer information that may be useful when troubleshooting connection issues.
+
+### Upload a file {#upload-a-file-windows}
+> [!Warning]
+> Once you upload a file to Codex, other nodes in the network can download it. Please do not upload anything you don't want others to access, or, properly encrypt your data *first*.
+
+```batch
+curl -X POST ^
+  http://localhost:8080/api/codex/v1/data ^
+  -H "Content-Type: application/octet-stream" ^
+  -T <FILE>
+```
+
+On successful upload, you'll receive a CID. This can be used to download the file from any node in the network.
+
+> [!TIP]
+> Are you on the [Codex Discord server](https://discord.gg/codex-storage)? Post your CID in the [# :wireless: | share-cids](https://discord.com/channels/895609329053474826/1278383098102284369) channel, see if others are able to download it. Codex does not (yet?) provide file metadata, so if you want others to be able to open your file, tell them which extension to give it.
+
+### Download a file {#download-a-file-windows}
+When you have a CID of data you want to download, you can use the following commands:
+
+```batch
+:: paste your CID from the previous step here between the quotes
+set CID="..."
+```
+
+```batch
+curl "http://localhost:8080/api/codex/v1/data/%CID%/network" ^
+  -o "%CID%.png"
+```
+
+Please use the correct extension for the downloaded file, because Codex does not store yet content-type or extension information.
+
+### Local data {#local-data-windows}
+You can view which datasets are currently being stored by your node:
+
+```batch
+curl http://localhost:8080/api/codex/v1/data
+```
+
+### Create storage availability {#create-storage-availability-windows}
+> [!WARNING]
+> This step requires that Codex was started with the [`prover`](/learn/run#codex-storage-node) option.
+
+In order to start selling storage space to the network, you must configure your node with the following command. Once configured, the node will monitor on-chain requests-for-storage and will automatically enter into contracts that meet these specifications. In order to enter and maintain storage contracts, your node is required to submit zero-knowledge storage proofs. The calculation of these proofs will increase the CPU and RAM usage of Codex.
+
+```batch
+curl -X POST ^
+  http://localhost:8080/api/codex/v1/sales/availability ^
+  -H "Content-Type: application/json" ^
+  -d "{""totalSize"": ""8000000"", ""duration"": ""7200"", ""minPrice"": ""10"", ""maxCollateral"": ""10""}"
+```
+
+For descriptions of each parameter, please view the [spec](https://api.codex.storage/#tag/Marketplace/operation/offerStorage).
+
+### Purchase storage {#purchase-storage-windows}
+To purchase storage space from the network, first you must upload your data. Once you have the CID, use the following to create a request-for-storage.
+
+Set your CID:
+
+```batch
+:: paste your CID from the previous step here between the quotes
+set CID="..."
+echo CID: %CID%
+```
+
+Next you can run:
+
+```batch
+curl -X POST ^
+  "http://localhost:8080/api/codex/v1/storage/request/%CID%" ^
+  -H "Content-Type: application/json" ^
+  -d "{""duration"": ""3600"",""reward"": ""1"", ""proofProbability"": ""5"", ""expiry"": ""1200"", ""nodes"": 5, ""tolerance"": 2, ""collateral"": ""1""}"
+```
+
+For descriptions of each parameter, please view the [spec](https://api.codex.storage/#tag/Marketplace/operation/createStorageRequest).
+
+When successful, this request will return a Purchase-ID.
+
+### View purchase status {#view-purchase-status-windows}
+Using a Purchase-ID, you can check the status of your request-for-storage contract:
+
+```batch
+:: paste your PURCHASE_ID from the previous step here between the quotes
+set PURCHASE_ID="..."
+```
+
+Then:
+
+```batch
+curl "http://localhost:8080/api/codex/v1/storage/purchases/%PURCHASE_ID%"
 ```
 
 This will display state and error information for your purchase.

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -16,7 +16,7 @@ We have several guides and you can use one more suitable for you
 Guides were tested on the following OS:
  - Linux: Ubuntu 24.04, Debian 12, Fedora 40
  - macOS: 15
- - Windows: 11, Srv 2022
+ - Windows: 11, Server 2022
 
 ## Discord guide
 


### PR DESCRIPTION
We've updated Using Codex pages with the guide for Windows and now we have full parity with guides from [codex-testnet-starter](https://github.com/codex-storage/codex-testnet-starter) repository.

Branch Preview URL: https://docs-add-using-codex-for-win.codex-docs-8lf.pages.dev