### PR TITLE
Fixes and improvements to testnet guides

### DIFF
--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -85,6 +85,10 @@ Please follow the steps for your OS from the list:
 1. Download binary and checksum for your platform/architecture
    > [!WARNING]
    > For Windows, only amd64 architecture is supported now.
+
+   > [!WARNING]
+   > Windows antivirus software and built-in firewalls may cause steps to fail. We will cover some possible errors here, but always consider checking your setup if requests fail.
+
    ```batch
    set version=v0.1.4
    set platform=windows
@@ -120,10 +124,10 @@ Please follow the steps for your OS from the list:
    move /Y %LOCALAPPDATA%\Codex\codex-%version%-%platform%-%architecture%.exe %LOCALAPPDATA%\Codex\codex.exe
 
    :: Add folder to the path permanently
-   setx PATH %PATH%%LOCALAPPDATA%\Codex;
+   setx PATH "%PATH%%LOCALAPPDATA%\Codex;"
 
    :: Add folder to the path for the current session
-   PATH %PATH%%LOCALAPPDATA%\Codex;
+   PATH "%PATH%%LOCALAPPDATA%\Codex;"
    ```
 
 4. Check the result
@@ -165,9 +169,13 @@ We may [run Codex in different modes](/learn/run#run), and for a quick start we 
    ```
 
    **Windows**
+
+   > [!WARNING]
+   > Windows might at this stage prompt you to grant internet access to Codex. You must allow it for things to work.
+
    ```batch
    :: Get Public IP
-   for /f "delims=" %a in ('curl -s https://ip.codex.storage') do @set nat=%a
+   for /f "delims=" %a in ('curl -s --ssl-reqd ip.codex.storage') do @set nat=%a
 
    :: Run
    codex ^

--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -18,7 +18,7 @@ Please follow the steps for your OS from the list:
 
 1. Download binary and checksum for your platform/architecture
    ```shell
-   version=v0.1.4
+   version=v0.1.5
    platform=$(echo `uname -s` | awk '{print tolower($0)}')
    architecture=$([[ `uname -m` == 'x86_64' ]] && echo amd64 || echo arm64)
 

--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -87,7 +87,7 @@ Please follow the steps for your OS from the list:
    > For Windows, only amd64 architecture is supported now.
 
    > [!WARNING]
-   > Windows antivirus software and built-in firewalls may cause steps to fail. We will cover some possible errors here, but always consider checking your setup if requests fail.
+   > Windows antivirus software and built-in firewalls may cause steps to fail. We will cover some possible errors here, but always consider checking your setup if requests fail - in particular, if temporarily disabling your antivirus fixes it, then it is likely to be the culprit.
 
    ```batch
    set version=v0.1.4
@@ -100,6 +100,18 @@ Please follow the steps for your OS from the list:
    :: Checksum
    curl -LO https://github.com/codex-storage/nim-codex/releases/download/%version%/codex-%version%-%platform%-%architecture%-libs.zip.sha256
    ```
+
+   If you see an error like:
+
+   ```batch
+   curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_NO_REVOCATION_CHECK (0x80092012) - The revocation function was unable to check revocation for the certificate.
+   ```
+
+   You may need to add the `--ssl-no-revoke` option to your curl calls, i.e., modify the calls above so they look like this:
+
+   ```batch
+    curl -LO --ssl-no-revoke https://...
+    ```
 
 2. Verify checksum
    ```batch

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -3,33 +3,36 @@ outline: [2, 4]
 ---
 # Codex Testnet
 
-Codex Testnet was launched and ready to be used for testing.
+The Codex Testnet has been launched and is ready to be used for testing.
 
 Your participation in the Codex Testnet is subject to the [Codex Testnet Terms and Conditions](https://github.com/codex-storage/codex-testnet-starter/blob/master/Codex%20Testnet%20Terms%20and%20Conditions.pdf) and [Codex Testnet Privacy Policy](https://github.com/codex-storage/codex-testnet-starter/blob/master/Codex%20Testnet%20Privacy%20Policy.pdf).
 
+**Guides.** We have basic guides covering how to set up a Storage Client which can be used to upload and persist files by buying storage in the Codex network. We recommend that you start with those.
 
-We have several guides and you can use one more suitable for you
-- [Discord guide](#discord-guide)
-- [Basic guide](#basic-guide)
-- [Advanced guide](#advanced-guide)
+Running a Storage Provider is more involved and is covered as a separate guide which demonstrates the storage sales side, as well as how to run Codex with its own local Ethereum execution client.
 
-Guides were tested on the following OS:
+Guides are available either on Discord, as step-by-step, interactive guides, or here as simple instructions that you can follow:
+
+- **Basic: running a storage client.** [[Discord](#sc-guide-discord) | [html](#sc-guide-web)]
+- **Advanced: Running a storage provider.** [[html](#sp-guide-web)]
+
+The guides were tested on the following operating systems:
+
  - Linux: Ubuntu 24.04, Debian 12, Fedora 40
  - macOS: 15
  - Windows: 11, Server 2022
 
-## Discord guide
+## Running a Storage Client (Discord Version) {#sc-guide-discord}
 
 You can join [Codex Discord server](https://discord.gg/codex-storage) and jump into the [#:tv:|join-testnet](https://discord.com/channels/895609329053474826/1289923125928001702) channel.
 
-It is mostly the same as a [Basic guide](#basic-guide), but uses Discord capabilities to make a walk-through and you also can get a support in the [#:sos:|node-help](https://discord.com/channels/895609329053474826/1286205545837105224) channel.
+It is mostly the same as a [Web guide](#sc-guide-web), but uses Discord capabilities so you can have an interactive, step-by-step guide, and you also can get a support in the [#:sos:|node-help](https://discord.com/channels/895609329053474826/1286205545837105224) channel.
 
-## Basic guide
+## Running a Storage Client (Web Version) {#sc-guide-web}
 
 **Prerequisites**
 
- - [Git installed](https://git-scm.com/downloads)
- - Configure port forwarding on your Internet router
+ - Access to your Internet router so you can [configure port forwarding](#basic-common)
 
 Steps for [Linux/macOS](#basic-linux-macos) and [Windows](#basic-windows) are slightly different, so please use ones for your OS.
 
@@ -37,14 +40,14 @@ Steps for [Linux/macOS](#basic-linux-macos) and [Windows](#basic-windows) are sl
 
 ### Linux/macOS {#basic-linux-macos}
 
-1. Open console and clone the repository:
+1. Download the master tarball from the Codex testnet starter repository, and untar its contents:
    ```shell
-   git clone https://github.com/codex-storage/codex-testnet-starter
+   curl -LO https://github.com/codex-storage/codex-testnet-starter/archive/master.tar.gz
    ```
 
 2. Navigate to the scripts folder:
    ```shell
-   cd codex-testnet-starter/scripts
+   cd codex-testnet-starter-master/scripts
    ```
 
 3. Install dependencies when required:
@@ -80,14 +83,35 @@ Steps for [Linux/macOS](#basic-linux-macos) and [Windows](#basic-windows) are sl
 
 ### Windows {#basic-windows}
 
-1. Open command prompt (`cmd`) and clone the repository:
+1. Download the master tarball from the Codex testnet starter repository, and untar its contents:
+   > [!WARNING]
+   > Windows antivirus software and built-in firewalls may cause steps to fail. We will cover some possible errors here, but always consider checking your setup if requests fail - in particular, if temporarily disabling your antivirus fixes it, then it is likely to be the culprit.
+
    ```batch
-   git clone https://github.com/codex-storage/codex-testnet-starter
+   curl -LO https://github.com/codex-storage/codex-testnet-starter/archive/master.tar.gz
+   ```
+
+   If you see an error like:
+
+   ```batch
+   curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_NO_REVOCATION_CHECK (0x80092012) - The revocation function was unable to check revocation for the certificate.
+   ```
+
+   You may need to add the `--ssl-no-revoke` option to your curl call, e.g.:
+
+   ```batch
+   curl -LO --ssl-no-revoke https://github.com/codex-storage/codex-testnet-starter/archive/master.tar.gz
+   ```
+
+1. Extract the contents of the tar file, and then delete it:
+   ```batch
+   tar xzvf master.tar.gz
+   del master.tar.gz
    ```
 
 2. Navigate to the scripts folder:
    ```batch
-   cd codex-testnet-starter\scripts\windows
+   cd codex-testnet-starter-master\scripts\windows
    ```
 
 3. Download Codex binaries from GitHub releases:
@@ -129,13 +153,13 @@ You also can use [Codex App UI](https://app.codex.storage) to interact with your
 
 Need help? Reach out to us in [#:sos:|node-help](https://discord.com/channels/895609329053474826/1286205545837105224) channel or check [troubleshooting guide](#troubleshooting).
 
-## Advanced guide
+## Running a Storage Provider (Web Version) {#sp-guide-web}
 
 Work in progress :construction:
 
-## Testnet data
+## Testnet Data
 
-### Bootstrap nodes
+### Bootstrap Nodes
 **Codex**
 ```shell
 spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -13,8 +13,8 @@ Running a Storage Provider is more involved and is covered as a separate guide w
 
 Guides are available either on Discord, as step-by-step, interactive guides, or here as simple instructions that you can follow:
 
-- **Basic: running a storage client.** [[Discord](#sc-guide-discord) | [html](#sc-guide-web)]
-- **Advanced: Running a storage provider.** [[html](#sp-guide-web)]
+- **Basic: running a storage client.** [[Discord](#sc-guide-discord) | [web](#sc-guide-web)]
+- **Advanced: Running a storage provider.** [[web](#sp-guide-web)]
 
 The guides were tested on the following operating systems:
 
@@ -43,6 +43,8 @@ Steps for [Linux/macOS](#basic-linux-macos) and [Windows](#basic-windows) are sl
 1. Download the master tarball from the Codex testnet starter repository, and untar its contents:
    ```shell
    curl -LO https://github.com/codex-storage/codex-testnet-starter/archive/master.tar.gz
+   tar xzvf master.tar.gz
+   rm master.tar.gz
    ```
 
 2. Navigate to the scripts folder:


### PR DESCRIPTION
This PR adds some fixes to the Windows guide:
1. use quotes with setx so whitespaces are not a problem;
2. use `--ssl-reqd` and `--ssl-no-revoke` to dodge flaky third-party anitivirus behavior (Avast).

It also simplifies the guides so they use the master tarballs for the testnet starter, doing away with the requirement of having git available. Finally, it bumps the client version to 0.1.5.

I also took the liberty to do some rewording of the intro text to the guides and tried to change their names to be more descriptive than basic/advanced. 