### PR TITLE
Update Codex Testnet marketplace contract address

### DIFF
--- a/learn/run.md
+++ b/learn/run.md
@@ -293,7 +293,7 @@ And to be able to purchase a storage, we should run [Codex node with marketplace
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6
+     --marketplace-address=0xfE822Df439d987849a90B64a4C0e26a297DBD47F
    ```
 
 > [!NOTE]
@@ -347,7 +347,7 @@ To download circuit files and make them available to Codex app, we have a stand-
    cirdl \
      datadir/circuits \
      https://rpc.testnet.codex.storage \
-     0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6
+     0xfE822Df439d987849a90B64a4C0e26a297DBD47F
    ```
 
 2. Start Codex storage node
@@ -361,7 +361,7 @@ To download circuit files and make them available to Codex app, we have a stand-
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6 \
+     --marketplace-address=0xfE822Df439d987849a90B64a4C0e26a297DBD47F \
      prover \
      --circuit-dir=datadir/circuits
    ```
@@ -486,7 +486,7 @@ docker run \
     persistence \
     --eth-provider=https://rpc.testnet.codex.storage \
     --eth-private-key=/opt/eth.key \
-    --marketplace-address=0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6 \
+    --marketplace-address=0xfE822Df439d987849a90B64a4C0e26a297DBD47F \
     prover \
     --circuit-dir=/datadir/circuits
 ```
@@ -549,7 +549,7 @@ For Docker Compose, it is more suitable to use [environment variables](#environm
           - CODEX_API_BINDADDR=0.0.0.0
           - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage
           - CODEX_ETH_PRIVATE_KEY=/opt/eth.key
-          - CODEX_MARKETPLACE_ADDRESS=0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6
+          - CODEX_MARKETPLACE_ADDRESS=0xfE822Df439d987849a90B64a4C0e26a297DBD47F
           - CODEX_CIRCUIT_DIR=/datadir/circuits
         ports:
           - 8080:8080/tcp # API

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -190,7 +190,7 @@ enode://6ba0e8b5d968ca8eb2650dd984cdcf50acc01e4ea182350e990191aadd79897801b79455
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Token       | [`0x34a22f3911De437307c6f4485931779670f78764`](https://explorer.testnet.codex.storage/address/0x34a22f3911De437307c6f4485931779670f78764) |
 | Verifier    | [`0x02dd582726F7507D7d0F8bD8bf8053d3006F9092`](https://explorer.testnet.codex.storage/address/0x02dd582726F7507D7d0F8bD8bf8053d3006F9092) |
-| Marketplace | [`0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6`](https://explorer.testnet.codex.storage/address/0xCDef8d6884557be4F68dC265b6bB2E3e52a6C9d6) |
+| Marketplace | [`0xfE822Df439d987849a90B64a4C0e26a297DBD47F`](https://explorer.testnet.codex.storage/address/0xfE822Df439d987849a90B64a4C0e26a297DBD47F) |
 
 ### Endpoints
 


### PR DESCRIPTION
We recently deployed(https://github.com/codex-storage/codex-contracts-eth/pull/190) a new version of the Marketplace smart contract on Codex Testnet.

PR updates the docs with the new address.