### PR TITLE
GCC 14 workaround + minor fixes

### DIFF
--- a/codex/disclaimer.md
+++ b/codex/disclaimer.md
@@ -1,4 +1,4 @@
-# Disclaimer Codex
+# Disclaimer
 
 The code and instructions provided within this repository and related repositories are provided “as-is”, without warranty of any kind, express or implied, including but not limited to the safety or correctness, or performance of the code or instructions provided. We make no assurance that the code will work as intended, and users may experience delays, failures, errors, omissions or loss of transmitted information whilst using or running Codex.
 

--- a/learn/build.md
+++ b/learn/build.md
@@ -28,6 +28,10 @@ The current implementation of Codex's zero-knowledge proving circuit requires th
 
 ### Linux
 
+> [!WARNING]
+> Linux builds currently require gcc $\leq$ 13. If this is not an option in your
+> system, you can try [building within Docker](#building-within-docker) as a workaround.
+
 *Package manager commands may require `sudo` depending on OS setup.*
 
 On a bare bones installation of Debian (or a distribution derived from Debian, such as Ubuntu), run
@@ -50,6 +54,16 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-
 
 . "$HOME/.cargo/env"
 ```
+
+Note that you will currently not be able to build Codex with gcc 14. To verify that 
+you have a supported version, run:
+
+``shell
+gcc --version
+```
+
+If you get a number that starts with 14 (e.g. `14.2.0`), then you need to either
+downgrade, or try a workaround like [building within Docker](#building-within-docker).
 
 ### macOS
 
@@ -208,6 +222,25 @@ Use a new terminal to run:
 make testAll
 ```
 
-## Known issues
+## Building Within Docker
 
-[^gcc-14]: At the moment Codex can't be compiled with GCC 14 - [[BUG] - Compile Codex with GCC 14 #875](https://github.com/codex-storage/nim-codex/issues/875).
+For the specific case of Linux distributions which ship with gcc 14
+and a downgrade to $3 is not possible/desirable, building within a Docker
+container and pulling the binaries out by copying or mounting remains an
+option; e.g.:
+
+```bash=
+# Clone original repo.
+git clone https://github.com/codex-storage/nim-codex
+
+# Build inside docker, with correct dependencies, using external repo.
+# This should also keep modifications in the external repo (to be tested).
+docker build -t codexstorage/nim-codex:latest -f nim-codex/docker/codex.Dockerfile nim-codex
+
+# Extract executable
+docker create --name=codex-build codexstorage/nim-codex:latest
+docker cp codex-build:/usr/local/bin/codex ./codex
+docker cp codex-build:/usr/local/bin/cirdl ./cirdl
+```
+
+and voilà, you should have the binaries available in the current folder.

--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -1,4 +1,4 @@
-# Quick start
+# Quick Start
 
 To run Codex through this guide we would need to perform the following steps:
 - [Review the disclaimer](/codex/disclaimer)


### PR DESCRIPTION
This PR adds:

* a temporary workaround for building binaries using docker in systems that ship GCC 14 and a clearer warning that it's currently not supported;
* some minor fixes to titles of existing pages.
