### PR TITLE
Update Testnet marketplace address

### DIFF
--- a/learn/quick-start.md
+++ b/learn/quick-start.md
@@ -31,11 +31,6 @@ Please follow the steps for your OS from the list:
    ```shell
    codex --version
    ```
-   ```shell
-   Codex version:  v0.1.6
-   Codex revision: 47061bf
-   Nim Compiler Version 1.6.21 [Linux: amd64]
-   ```
 
 ### Windows
 
@@ -47,7 +42,6 @@ Please follow the steps for your OS from the list:
    > Windows antivirus software and built-in firewalls may cause steps to fail. We will cover some possible errors here, but always consider checking your setup if requests fail - in particular, if temporarily disabling your antivirus fixes it, then it is likely to be the culprit.
 
    ```batch
-   set version=v0.1.6
    set platform=windows
    if %PROCESSOR_ARCHITECTURE%==AMD64 (set architecture=amd64) else (set architecture=arm64)
 
@@ -79,7 +73,7 @@ Please follow the steps for your OS from the list:
 
    Make sure you get `OK` in the result
    ```
-   codex-v0.1.6-windows-amd64-libs.zip: OK
+   codex-v0.1.7-windows-amd64-libs.zip: OK
    ```
 
 3. Extract binary and libraries
@@ -102,16 +96,6 @@ Please follow the steps for your OS from the list:
 4. Check the result
    ```shell
    codex --version
-   ```
-   ```shell
-   Codex version:  v0.1.6
-   Codex revision: 47061bf
-   Nim Compiler Version 1.6.21 [Windows: amd64]
-   Compiled at 2024-06-27
-   Copyright (c) 2006-2023 by Andreas Rumpf
-
-   git hash: 38640664088251bbc88917b4bacfd86ec53014b8
-   active boot switches: -d:release
    ```
 
 5. Cleanup

--- a/learn/run.md
+++ b/learn/run.md
@@ -293,7 +293,7 @@ And to be able to purchase a storage, we should run [Codex node with marketplace
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xfE822Df439d987849a90B64a4C0e26a297DBD47F
+     --marketplace-address=0x3F9Cf3F40F0e87d804B776D8403e3d29F85211f4
    ```
 
 > [!NOTE]
@@ -347,7 +347,7 @@ To download circuit files and make them available to Codex app, we have a stand-
    cirdl \
      datadir/circuits \
      https://rpc.testnet.codex.storage \
-     0xfE822Df439d987849a90B64a4C0e26a297DBD47F
+     0x3F9Cf3F40F0e87d804B776D8403e3d29F85211f4
    ```
 
 2. Start Codex storage node
@@ -361,7 +361,7 @@ To download circuit files and make them available to Codex app, we have a stand-
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xfE822Df439d987849a90B64a4C0e26a297DBD47F \
+     --marketplace-address=0x3F9Cf3F40F0e87d804B776D8403e3d29F85211f4 \
      prover \
      --circuit-dir=datadir/circuits
    ```
@@ -486,7 +486,7 @@ docker run \
     persistence \
     --eth-provider=https://rpc.testnet.codex.storage \
     --eth-private-key=/opt/eth.key \
-    --marketplace-address=0xfE822Df439d987849a90B64a4C0e26a297DBD47F \
+    --marketplace-address=0x3F9Cf3F40F0e87d804B776D8403e3d29F85211f4 \
     prover \
     --circuit-dir=/datadir/circuits
 ```
@@ -549,7 +549,7 @@ For Docker Compose, it is more suitable to use [environment variables](#environm
           - CODEX_API_BINDADDR=0.0.0.0
           - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage
           - CODEX_ETH_PRIVATE_KEY=/opt/eth.key
-          - CODEX_MARKETPLACE_ADDRESS=0xfE822Df439d987849a90B64a4C0e26a297DBD47F
+          - CODEX_MARKETPLACE_ADDRESS=0x3F9Cf3F40F0e87d804B776D8403e3d29F85211f4
           - CODEX_CIRCUIT_DIR=/datadir/circuits
         ports:
           - 8080:8080/tcp # API

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -190,7 +190,7 @@ enode://6ba0e8b5d968ca8eb2650dd984cdcf50acc01e4ea182350e990191aadd79897801b79455
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Token       | [`0x34a22f3911De437307c6f4485931779670f78764`](https://explorer.testnet.codex.storage/address/0x34a22f3911De437307c6f4485931779670f78764) |
 | Verifier    | [`0x02dd582726F7507D7d0F8bD8bf8053d3006F9092`](https://explorer.testnet.codex.storage/address/0x02dd582726F7507D7d0F8bD8bf8053d3006F9092) |
-| Marketplace | [`0xfE822Df439d987849a90B64a4C0e26a297DBD47F`](https://explorer.testnet.codex.storage/address/0xfE822Df439d987849a90B64a4C0e26a297DBD47F) |
+| Marketplace | [`0x3F9Cf3F40F0e87d804B776D8403e3d29F85211f4`](https://explorer.testnet.codex.storage/address/0x3F9Cf3F40F0e87d804B776D8403e3d29F85211f4) |
 
 ### Endpoints
 


### PR DESCRIPTION
PR update Codex Testnet address to the latest one (https://github.com/codex-storage/infra-codex/issues/248) and we also updated binary reference to the latest release.