### PR TITLE
Update Download to reflect API changes

### DIFF
--- a/learn/using.md
+++ b/learn/using.md
@@ -56,7 +56,7 @@ CID="..."
 ```
 
 ```shell
-curl "http://localhost:8080/api/codex/v1/data/${CID}/network" \
+curl "http://localhost:8080/api/codex/v1/data/${CID}/network/stream" \
   -o "${CID}.png"
 ```
 
@@ -194,7 +194,7 @@ set CID="..."
 ```
 
 ```batch
-curl "http://localhost:8080/api/codex/v1/data/%CID%/network" ^
+curl "http://localhost:8080/api/codex/v1/data/%CID%/network/stream" ^
   -o "%CID%.png"
 ```
 


### PR DESCRIPTION
In Codex 0.1.7 release, there were some changes in download API. Now, we should use [downloadNetworkStream](https://api.codex.storage/#tag/Data/operation/downloadNetworkStream) to retrieve a file..