### PR TITLE
docs: add tokenomics litepaper to the sidebar

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -91,6 +91,7 @@ export default withMermaid({
           { text: 'What is Codex?', link: '/learn/what-is-codex' },
           { text: 'Architecture', link: '/learn/architecture' },
           { text: 'Whitepaper', link: '/learn/whitepaper' },
+          { text: 'Tokenomics Litepaper', link: '/learn/tokenomics-litepaper' }
         ]
       },
       {


### PR DESCRIPTION
A quick PR and it is a #57 follow up to add _Tokenomics Litepaper_ to the sidebar

**Preview** - https://docs-add-tokenomics-litepape.codex-docs-8lf.pages.dev

<img width="1174" alt="Screenshot 2025-01-24 at 14 52 22" src="https://github.com/user-attachments/assets/426ba11b-233b-4a41-a575-2246275567d1" />
