### PR TITLE
Updates reward and collateral options

### DIFF
--- a/learn/local-marketplace.md
+++ b/learn/local-marketplace.md
@@ -268,7 +268,7 @@ npm install
 ```
 
 > While writing the document we used `node` version `v20.17.0` and
-> `npm` version `10.8.2`.
+> `npm` version `11.0.0`.
 
 Before continuing you now must **wait until $256$ blocks are mined**
 **in your PoAnetwork**, or deploy will fail. This should take about
@@ -525,8 +525,8 @@ curl 'http://localhost:8000/api/codex/v1/sales/availability' \
   --data '{
   "totalSize": "50000000",
   "duration": "3600",
-  "minPrice": "1",
-  "maxCollateral": "1000"
+  "minPricePerBytePerSecond": "1000",
+  "totalCollateral": "50000000"
 }'
 ```
 
@@ -585,12 +585,12 @@ curl "http://localhost:8001/api/codex/v1/storage/request/${CID}" \
   --header 'Content-Type: application/octet-stream' \
   --data "{
     \"duration\": \"600\",
-    \"reward\": \"1\",
+    \"pricePerBytePerSecond\": \"2000\",
     \"proofProbability\": \"3\",
     \"expiry\": \"500\",
     \"nodes\": 3,
     \"tolerance\": 1,
-    \"collateral\": \"1000\"
+    \"collateralPerByte\": \"1\"
   }" \
   --write-out '\n'
 ```
@@ -639,14 +639,14 @@ This returns a result like:
       "slotSize": "262144",
       "duration": "1000",
       "proofProbability": "3",
-      "reward": "1",
-      "collateral": "1",
+      "pricePerBytePerSecond": "2000",
+      "collateralPerByte": 1,
       "maxSlotLoss": 1
     },
     "content": {
       "cid": "zDvZRwzkyw1E7ABaUSmgtNEDjC7opzhUoHo99Vpvc98cDWeCs47u"
     },
-    "expiry": "1711992852",
+    "expiry": "500",
     "nonce": "0x9f5e651ecd3bf73c914f8ed0b1088869c64095c0d7bd50a38fc92ebf66ff5915",
     "id": "0x6c698cd0ad71c41982f83097d6fa75beb582924e08a658357a1cd4d7a2a6766d"
   },

--- a/learn/using.md
+++ b/learn/using.md
@@ -84,8 +84,8 @@ curl -X POST \
   -d '{
     "totalSize": "8000000",
     "duration": "7200",
-    "minPrice": "10",
-    "maxCollateral": "10"
+    "minPricePerBytePerSecond": "1000",
+    "totalCollateral": "80000000"
   }'
 ```
 
@@ -110,12 +110,12 @@ curl -X POST \
   -w '\n' \
   -d '{
     "duration": "3600",
-    "reward": "1",
+    "pricePerBytePerSecond": "2000",
     "proofProbability": "5",
     "expiry": "1200",
     "nodes": 5,
     "tolerance": 2,
-    "collateral": "1"
+    "collateralPerByte": "1"
   }'
 ```
 
@@ -217,7 +217,7 @@ In order to start selling storage space to the network, you must configure your 
 curl -X POST ^
   http://localhost:8080/api/codex/v1/sales/availability ^
   -H "Content-Type: application/json" ^
-  -d "{""totalSize"": ""8000000"", ""duration"": ""7200"", ""minPrice"": ""10"", ""maxCollateral"": ""10""}"
+  -d "{""totalSize"": ""8000000"", ""duration"": ""7200"", ""minPricePerBytePerSecond"": ""1000"", ""totalCollateral"": ""80000000""}"
 ```
 
 For descriptions of each parameter, please view the [spec](https://api.codex.storage/#tag/Marketplace/operation/offerStorage).
@@ -239,7 +239,7 @@ Next you can run:
 curl -X POST ^
   "http://localhost:8080/api/codex/v1/storage/request/%CID%" ^
   -H "Content-Type: application/json" ^
-  -d "{""duration"": ""3600"",""reward"": ""1"", ""proofProbability"": ""5"", ""expiry"": ""1200"", ""nodes"": 5, ""tolerance"": 2, ""collateral"": ""1""}"
+  -d "{""duration"": ""3600"",""pricePerBytePerSecond"": ""2000"", ""proofProbability"": ""5"", ""expiry"": ""1200"", ""nodes"": 5, ""tolerance"": 2, ""**collateralPerByte**"": ""1""}"
 ```
 
 For descriptions of each parameter, please view the [spec](https://api.codex.storage/#tag/Marketplace/operation/createStorageRequest).


### PR DESCRIPTION
Since we are using `collateralPerByte` and `pricePerBytePerSecond`, the docs need to be aligned with that.