### PR TITLE
feat: add internationalization support

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -151,5 +151,101 @@ export default withMermaid({
       { icon: 'youtube', link: 'https://www.youtube.com/@CodexStorage' },
       { icon: 'discord', link: 'https://discord.gg/codex-storage' }
     ]
+  },
+
+  // Internationalization - https://vitepress.dev/guide/i18n
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en'
+    },
+    // Korean
+  //   ko: {
+  //     label: '한국어',
+  //     lang: 'ko-KP',
+  //     link: '/ko',
+  //     themeConfig: {
+  //       nav: [
+  //         { text: '백서', link: '/ko/learn/whitepaper' },
+  //         { text: 'Tokenomics Litepaper', link: '/ko/learn/tokenomics-litepaper' },
+  //         {
+  //           text: 'Codex',
+  //           items: [
+  //             { text: '소개', link: '/ko/codex/about' },
+  //             { text: '보안', link: '/ko/codex/security' },
+  //             { text: '개인정보 처리방침', link: '/ko/codex/privacy-policy' },
+  //             { text: '이용 약관', link: '/ko/codex/terms-of-use' }
+  //           ]
+  //         }
+  //       ],
+  //       editLink: {
+  //         pattern: 'https://github.com/codex-storage/codex-docs/edit/master/:path',
+  //         text: 'Edit this page on GitHub',
+  //       },
+  //       siteTitle: 'Codex • 문서',
+  //       logoLink: '/ko/learn/what-is-codex',
+  //       sidebar: [
+  //         {
+  //           text: 'Introduction',
+  //           collapsed: false,
+  //           items: [
+  //             { text: 'Codex란 무엇인가?', link: '/ko/learn/what-is-codex' },
+  //             { text: '아키텍처', link: '/ko/learn/architecture' },
+  //             { text: '백서', link: '/ko/learn/whitepaper' },
+  //             { text: 'Tokenomics Litepaper', link: '/ko/learn/tokenomics-litepaper' }
+  //           ]
+  //         },
+  //         {
+  //           text: 'Setup Codex with Installer',
+  //           collapsed: false,
+  //           items: [
+  //             { text: '면책 조항', link: '/ko/codex/installer-disclaimer' },
+  //             { text: 'Requirements', link: '/ko/learn/installer/requirements' },
+  //             { text: 'Install and Run Codex', link: '/ko/learn/installer/install-and-run' },
+  //             { text: 'Upload/Download', link: '/ko/learn/installer/upload-and-download' },
+  //           ]
+  //         },
+  //         {
+  //           text: 'Setup Codex Manually',
+  //           collapsed: false,
+  //           items: [
+  //             { text: '면책 조항', link: '/ko/codex/disclaimer' },
+  //             { text: '빠른 시작', link: '/ko/learn/quick-start' },
+  //             { text: 'Build Codex', link: '/ko/learn/build' },
+  //             { text: 'Run Codex', link: '/ko/learn/run' },
+  //             { text: '사용하기', link: '/ko/learn/using' },
+  //             { text: 'Local Two Client Test', link: '/ko/learn/local-two-client-test' },
+  //             { text: 'Local Marketplace', link: '/ko/learn/local-marketplace' },
+  //             { text: 'Download Flow', link: '/ko/learn/download-flow' },
+  //             { text: '문제 해결', link: '/ko/learn/troubleshoot' }
+  //           ]
+  //         },
+  //         {
+  //           text: 'Codex networks',
+  //           collapsed: false,
+  //           items: [
+  //             { text: '테스트넷', link: '/ko/networks/testnet' }
+  //           ]
+  //         },
+  //         {
+  //           text: 'Developers',
+  //           collapsed: false,
+  //           items: [
+  //             { text: 'API', link: '/developers/api' }
+  //           ]
+  //         },
+  //         {
+  //           text: 'Codex',
+  //           collapsed: false,
+  //           items: [
+  //             { text: '소개', link: '/ko/codex/about' },
+  //             { text: '보안', link: '/ko/codex/security' },
+  //             { text: '개인정보 처리방침', link: '/ko/codex/privacy-policy' },
+  //             { text: '이용 약관', link: '/ko/codex/terms-of-use' }
+  //           ]
+  //         }
+  //       ],
+  //     }
+  //   }
   }
 })

--- a/README.md
+++ b/README.md
@@ -76,3 +76,47 @@
  - `learn` - All information to learn about Codex
  - `networks` - Codex networks related information
  - `developers` - Codex development process and guides
+
+
+## Internationalization
+
+ We are using built-in [i18n features for Internationalization support](https://vitepress.dev/guide/i18n).
+
+ In order to add a new language version of the docs it is required
+ 1. Create a folder with a name of the two letter language code - `ko` for Korean, please check [List of ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes).
+
+ 2. Copy and translate required pages. It make sense to use English pages as a source as it is the primary language. Pages are located inside the repository sub-folders
+    - *codex*
+    - *developers*
+    - *learn*
+    - *networks*
+
+    After translation, we will have a new folder with all sub-folders
+    ```
+    ko
+    ├── codex
+    ├── developers
+    ├── learn
+    └── networks
+    ```
+
+ 3. If you need to translate images, they are located inside a *public* folder. After translation, add a language suffix to the language specific file, for example *public/learn/architecture-`ko`.png*.
+
+    Then, update the docs to use a language specific image.
+
+ 4. Add new language to the site config file - [*.vitepress/config.mts*](.vitepress/config.mts)
+    ```json
+    // Korean
+    ko: {
+      label: '한국어',
+      lang: 'ko-KP',
+      link: '/ko',
+      themeConfig: {}
+    }
+    ```
+    - `label` - Native language name from [List of ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes)
+    - `lang` - [\<Language code\>](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes)-[\<Country code\>](https://en.wikipedia.org/wiki/ISO_3166-1)
+    - `link` - link to the index document located in the language specific folder
+    - `themeConfig` - contains translation of the site elements like Nav/Side bar, etc.
+
+ After performed changes, we should have a documentation site in a newly added language.


### PR DESCRIPTION
PR adds initial [Internationalization](https://vitepress.dev/guide/i18n) support.

It is related to some recent PRs
 - #62
 - #69

We have added
- Basic guide in the main readme, how to add new language version of the documentation
- A config example for Korean language, which can be used in conjunction with the #69