### PR TITLE
chore: update codex to release 0.2.1

### DIFF
--- a/ko/learn/run.md
+++ b/ko/learn/run.md
@@ -293,7 +293,7 @@ And to be able to purchase a storage, we should run [Codex node with marketplace
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xAB03b6a58C5262f530D54146DA2a552B1C0F7648
+     --marketplace-address=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3
    ```
 
 > [!NOTE]
@@ -347,7 +347,7 @@ To download circuit files and make them available to Codex app, we have a stand-
    cirdl \
      datadir/circuits \
      https://rpc.testnet.codex.storage \
-     0xAB03b6a58C5262f530D54146DA2a552B1C0F7648
+     0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3
    ```
 
 2. Start Codex storage node
@@ -361,7 +361,7 @@ To download circuit files and make them available to Codex app, we have a stand-
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xAB03b6a58C5262f530D54146DA2a552B1C0F7648 \
+     --marketplace-address=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3 \
      prover \
      --circuit-dir=datadir/circuits
    ```
@@ -486,7 +486,7 @@ docker run \
     persistence \
     --eth-provider=https://rpc.testnet.codex.storage \
     --eth-private-key=/opt/eth.key \
-    --marketplace-address=0xAB03b6a58C5262f530D54146DA2a552B1C0F7648 \
+    --marketplace-address=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3 \
     prover \
     --circuit-dir=/datadir/circuits
 ```
@@ -549,7 +549,7 @@ For Docker Compose, it is more suitable to use [environment variables](#environm
           - CODEX_API_BINDADDR=0.0.0.0
           - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage
           - CODEX_ETH_PRIVATE_KEY=/opt/eth.key
-          - CODEX_MARKETPLACE_ADDRESS=0xAB03b6a58C5262f530D54146DA2a552B1C0F7648
+          - CODEX_MARKETPLACE_ADDRESS=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3
           - CODEX_CIRCUIT_DIR=/datadir/circuits
         ports:
           - 8080:8080/tcp # API

--- a/ko/networks/testnet.md
+++ b/ko/networks/testnet.md
@@ -201,8 +201,8 @@ enode://6ba0e8b5d968ca8eb2650dd984cdcf50acc01e4ea182350e990191aadd79897801b79455
 | Contract    | Address                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Token       | [`0x34a22f3911De437307c6f4485931779670f78764`](https://explorer.testnet.codex.storage/address/0x34a22f3911De437307c6f4485931779670f78764) |
-| Verifier    | [`0x02dd582726F7507D7d0F8bD8bf8053d3006F9092`](https://explorer.testnet.codex.storage/address/0x02dd582726F7507D7d0F8bD8bf8053d3006F9092) |
-| Marketplace | [`0xAB03b6a58C5262f530D54146DA2a552B1C0F7648`](https://explorer.testnet.codex.storage/address/0xAB03b6a58C5262f530D54146DA2a552B1C0F7648) |
+| Verifier    | [`0x1f60B2329775545AaeF743dbC3571e699405263e`](https://explorer.testnet.codex.storage/address/0x1f60B2329775545AaeF743dbC3571e699405263e) |
+| Marketplace | [`0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3`](https://explorer.testnet.codex.storage/address/0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3) |
 
 ### Endpoints
 

--- a/learn/run.md
+++ b/learn/run.md
@@ -297,7 +297,7 @@ And to be able to purchase a storage, we should run [Codex node with marketplace
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed
+     --marketplace-address=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3
    ```
 
 > [!NOTE]
@@ -351,7 +351,7 @@ To download circuit files and make them available to Codex app, we have a stand-
    cirdl \
      datadir/circuits \
      https://rpc.testnet.codex.storage \
-     0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed
+     0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3
    ```
 
 2. Start Codex storage node
@@ -365,7 +365,7 @@ To download circuit files and make them available to Codex app, we have a stand-
      persistence \
      --eth-provider=https://rpc.testnet.codex.storage \
      --eth-private-key=eth.key \
-     --marketplace-address=0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed \
+     --marketplace-address=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3 \
      prover \
      --circuit-dir=datadir/circuits
    ```
@@ -604,7 +604,7 @@ docker run \
     persistence \
     --eth-provider=https://rpc.testnet.codex.storage \
     --eth-private-key=/opt/eth.key \
-    --marketplace-address=0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed \
+    --marketplace-address=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3 \
     prover \
     --circuit-dir=/datadir/circuits
 ```
@@ -667,7 +667,7 @@ For Docker Compose, it is more suitable to use [environment variables](#environm
           - CODEX_API_BINDADDR=0.0.0.0
           - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage
           - CODEX_ETH_PRIVATE_KEY=/opt/eth.key
-          - CODEX_MARKETPLACE_ADDRESS=0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed
+          - CODEX_MARKETPLACE_ADDRESS=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3
           - CODEX_CIRCUIT_DIR=/datadir/circuits
         ports:
           - 8080:8080/tcp # API

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -189,8 +189,8 @@ enode://6ba0e8b5d968ca8eb2650dd984cdcf50acc01e4ea182350e990191aadd79897801b79455
 | Contract    | Address                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Token       | [`0x34a22f3911De437307c6f4485931779670f78764`](https://explorer.testnet.codex.storage/address/0x34a22f3911De437307c6f4485931779670f78764) |
-| Verifier    | [`0x02dd582726F7507D7d0F8bD8bf8053d3006F9092`](https://explorer.testnet.codex.storage/address/0x02dd582726F7507D7d0F8bD8bf8053d3006F9092) |
-| Marketplace | [`0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed`](https://explorer.testnet.codex.storage/address/0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed) |
+| Verifier    | [`0x1f60B2329775545AaeF743dbC3571e699405263e`](https://explorer.testnet.codex.storage/address/0x1f60B2329775545AaeF743dbC3571e699405263e) |
+| Marketplace | [`0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3`](https://explorer.testnet.codex.storage/address/0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3) |
 
 ### Endpoints
 


### PR DESCRIPTION
This PR update the docs to follow up Codex release 0.2.1
 - Marketplace contract address was updated

Part of https://github.com/codex-storage/nim-codex/issues/1203.

