### PR TITLE
docs(testnet): use marketplace endpoint for a current contract address

### DIFF
--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -190,7 +190,7 @@ enode://6ba0e8b5d968ca8eb2650dd984cdcf50acc01e4ea182350e990191aadd79897801b79455
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Token       | [`0x34a22f3911De437307c6f4485931779670f78764`](https://explorer.testnet.codex.storage/address/0x34a22f3911De437307c6f4485931779670f78764) |
 | Verifier    | [`0x1f60B2329775545AaeF743dbC3571e699405263e`](https://explorer.testnet.codex.storage/address/0x1f60B2329775545AaeF743dbC3571e699405263e) |
-| Marketplace | [`0xd53a4181862f42641ccA02Fb4CED7D7f19C6920B`](https://explorer.testnet.codex.storage/address/0xd53a4181862f42641ccA02Fb4CED7D7f19C6920B) |
+| Marketplace | [`marketplace.codex.storage/codex-testnet/latest`](https://marketplace.codex.storage/codex-testnet/latest)                                |
 
 ### Endpoints
 


### PR DESCRIPTION
PR switch marketplace address to an endpoint, which return latest contracts address.

In that way it will not be required to update marketplace address in the documentation all the time and just on endpoint.

Part of https://github.com/codex-storage/nim-codex/issues/1282.